### PR TITLE
Fix: use XDG-compliant config path ~/.config/navicli/config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ sudo mv navicli /usr/local/bin/
 ```
 
 ### Configuration
-Create a config file at `~/.config/config.toml`:
+Create a config file at `~/.config/navicli/config.toml`:
 ```toml
 [server]
 url = "https://your-navidrome-server.com"
 username = "your-username"
 password = "your-password"
 ```
+
+The legacy path `~/.config/config.toml` is also supported for backward compatibility.
 
 ## Usage
 ```bash

--- a/config/loader.go
+++ b/config/loader.go
@@ -9,6 +9,7 @@ import (
 func Load() (*Config, error) {
 	viper.SetConfigName("config")
 	viper.SetConfigType("toml")
+	viper.AddConfigPath("$HOME/.config/navicli/")
 	viper.AddConfigPath("$HOME/.config/")
 	viper.AddConfigPath(".")
 


### PR DESCRIPTION
## Summary

Change the primary config file location from `~/.config/config.toml` to `~/.config/navicli/config.toml`.

## Changes
- `config/loader.go`: Add `~/.config/navicli/` as the primary search path, keep `~/.config/` as fallback for backward compatibility
- `README.md`: Update configuration section to reference the new path

## Why
The old path `~/.config/config.toml` is too generic and doesn't follow XDG conventions. The new path `~/.config/navicli/config.toml` is more idiomatic.

Closes #9