### PR TITLE
fix: album pagination, arrow indicator refresh, and dead code cleanup

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -10,6 +10,7 @@ password = "aaa"
 # User interface settings (OPTIONAL - defaults shown)
 [ui]
 page_size = 20             # Number of songs displayed per page
+fetch_size = 500           # Max songs to fetch via getRandomSongs (server may cap lower)
 progress_bar_width = 30    # Width of progress bar in characters
 max_column_width = 40      # Maximum width for table columns
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type ServerConfig struct {
 
 type UIConfig struct {
 	PageSize         int `mapstructure:"page_size"`
+	FetchSize        int `mapstructure:"fetch_size"`
 	ProgressBarWidth int `mapstructure:"progress_bar_width"`
 	MaxColumnWidth   int `mapstructure:"max_column_width"`
 }
@@ -38,6 +39,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		UI: UIConfig{
 			PageSize:         20,
+			FetchSize:        500,
 			ProgressBarWidth: 30,
 			MaxColumnWidth:   40,
 		},

--- a/config/loader.go
+++ b/config/loader.go
@@ -15,6 +15,7 @@ func Load() (*Config, error) {
 
 	defaults := DefaultConfig()
 	viper.SetDefault("ui.page_size", defaults.UI.PageSize)
+	viper.SetDefault("ui.fetch_size", defaults.UI.FetchSize)
 	viper.SetDefault("ui.progress_bar_width", defaults.UI.ProgressBarWidth)
 	viper.SetDefault("ui.max_column_width", defaults.UI.MaxColumnWidth)
 	viper.SetDefault("player.http_timeout", defaults.Player.HTTPTimeout)

--- a/device/audio_monitor.go
+++ b/device/audio_monitor.go
@@ -132,19 +132,6 @@ func (m *AudioMonitor) monitorLoop() {
 	}
 }
 
-func (m *AudioMonitor) getCurrentAudioDevice() *AudioDeviceInfo {
-	if !m.supported {
-		return nil
-	}
-
-	records := getAudioDeviceRecords()
-	if info := selectCurrentDevice(records); info != nil {
-		return info
-	}
-
-	return m.getAudioDeviceViaOsascript()
-}
-
 func (m *AudioMonitor) getAudioDeviceViaOsascript() *AudioDeviceInfo {
 	if !m.supported {
 		return nil
@@ -503,12 +490,4 @@ func deviceNameMatches(name1, name2 string) bool {
 	}
 
 	return false
-}
-
-func (m *AudioMonitor) GetCurrentDevice() *AudioDeviceInfo {
-	if !m.supported {
-		return nil
-	}
-
-	return m.getCurrentAudioDevice()
 }

--- a/library/interface.go
+++ b/library/interface.go
@@ -4,7 +4,7 @@ import "github.com/yhkl-dev/NaviCLI/domain"
 
 type Library interface {
 	GetRandomSongs(count int) ([]domain.Song, error)
-	GetAlbumSongs(albumType string, size int) ([]domain.Song, error)
+	GetAlbumSongs(albumType string) ([]domain.Song, error)
 	SearchSongs(query string, limit int) ([]domain.Song, error)
 	GetPlayURL(songID string) string
 	GetCoverArtURL(coverArtID string) string

--- a/library/subsonic.go
+++ b/library/subsonic.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"log"
 	"time"
 
 	"github.com/yhkl-dev/NaviCLI/domain"
@@ -25,23 +26,33 @@ func (s *SubsonicLibrary) GetRandomSongs(count int) ([]domain.Song, error) {
 	return convertToDomainSongs(songs), nil
 }
 
-func (s *SubsonicLibrary) GetAlbumSongs(albumType string, size int) ([]domain.Song, error) {
-	if size <= 0 {
-		size = 20
-	}
-	albums, err := s.client.GetAlbumList2(albumType, size)
-	if err != nil {
-		return nil, err
-	}
+func (s *SubsonicLibrary) GetAlbumSongs(albumType string) ([]domain.Song, error) {
+	const batchSize = 50 // albums per paginated fetch
 
 	var allSongs []domain.Song
-	for _, album := range albums {
-		songs, err := s.client.GetAlbum(album.ID)
+	offset := 0
+	for {
+		albums, err := s.client.GetAlbumList2(albumType, batchSize, offset)
 		if err != nil {
-			continue
+			return nil, err
 		}
-		domainSongs := convertToDomainSongs(songs)
-		allSongs = append(allSongs, domainSongs...)
+		if len(albums) == 0 {
+			break
+		}
+
+		for _, album := range albums {
+			songs, err := s.client.GetAlbum(album.ID)
+			if err != nil {
+				log.Printf("skip album %s: %v", album.Name, err)
+				continue
+			}
+			allSongs = append(allSongs, convertToDomainSongs(songs)...)
+		}
+
+		if len(albums) < batchSize {
+			break
+		}
+		offset += batchSize
 	}
 	return allSongs, nil
 }

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -41,18 +41,6 @@ func (m *Mpvplayer) GetProgress() (float64, error) {
 	return val, nil
 }
 
-func (m *Mpvplayer) GetDuration() (float64, error) {
-	duration, err := m.GetProperty("duration", mpv.FORMAT_DOUBLE)
-	if err != nil {
-		return 0, err
-	}
-	val, ok := duration.(float64)
-	if !ok {
-		return 0, fmt.Errorf("unexpected type for duration: %T", duration)
-	}
-	return val, nil
-}
-
 func (m *Mpvplayer) GetVolume() (float64, error) {
 	volume, err := m.GetProperty("volume", mpv.FORMAT_DOUBLE)
 	if err != nil {

--- a/player/interface.go
+++ b/player/interface.go
@@ -26,9 +26,6 @@ type Player interface {
 	// SetVolume sets the volume level (0-100)
 	SetVolume(volume float64) error
 
-	// IsPlaying returns whether audio is currently playing
-	IsPlaying() bool
-
 	// IsPaused returns whether playback is currently paused
 	IsPaused() (bool, error)
 
@@ -53,8 +50,5 @@ type Player interface {
 
 // PlayerConstants defines player state constants
 const (
-	PlayerStopped = iota
-	PlayerPlaying
-	PlayerPaused
-	PlayerError
+	PlayerError = iota + 3
 )

--- a/player/mpv.go
+++ b/player/mpv.go
@@ -98,18 +98,6 @@ func (p *MPVPlayer) SetVolume(volume float64) error {
 	return p.instance.Command([]string{"set", "volume", fmt.Sprintf("%.0f", volume)})
 }
 
-func (p *MPVPlayer) IsPlaying() bool {
-	paused, err := p.IsPaused()
-	if err != nil {
-		return false
-	}
-	loaded, err := p.IsSongLoaded()
-	if err != nil {
-		return false
-	}
-	return loaded && !paused
-}
-
 func (p *MPVPlayer) IsPaused() (bool, error) {
 	if p.instance == nil {
 		return false, fmt.Errorf("MPV instance not initialized")

--- a/subsonic/model.go
+++ b/subsonic/model.go
@@ -15,23 +15,6 @@ type Client struct {
 	HttpClient *http.Client
 }
 
-type SubsonicResponse struct {
-	Response struct {
-		Status        string `json:"status"`
-		Version       string `json:"version"`
-		Type          string `json:"type"`
-		ServerVersion string `json:"serverVersion"`
-		OpenSubsonic  bool   `json:"openSubsonic"`
-		RandomSongs   struct {
-			Songs []Song `json:"song"`
-		} `json:"randomSongs"`
-		Error struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error,omitempty"`
-	} `json:"subsonic-response"`
-}
-
 type AlbumID3 struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`

--- a/subsonic/player.go
+++ b/subsonic/player.go
@@ -147,13 +147,14 @@ func (c *Client) GetPlayURL(songID string) string {
 	return fmt.Sprintf("%s/rest/stream.view?%s", c.BaseURL, params.Encode())
 }
 
-func (c *Client) GetAlbumList2(albumType string, size int) ([]AlbumID3, error) {
+func (c *Client) GetAlbumList2(albumType string, size, offset int) ([]AlbumID3, error) {
 	if size <= 0 {
 		size = 20
 	}
 	params, err := c.buildParams(map[string]string{
-		"type": albumType,
-		"size": fmt.Sprintf("%d", size),
+		"type":   albumType,
+		"size":   fmt.Sprintf("%d", size),
+		"offset": fmt.Sprintf("%d", offset),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build params: %w", err)

--- a/ui/app.go
+++ b/ui/app.go
@@ -116,7 +116,7 @@ func (a *App) Stop() {
 }
 
 func (a *App) loadMusic() {
-	loadSize := a.cfg.UI.PageSize * 10
+	fetchSize := a.cfg.UI.FetchSize
 	var songs []domain.Song
 	var err error
 
@@ -124,9 +124,9 @@ func (a *App) loadMusic() {
 	src := a.songSource
 	a.songsMu.RUnlock()
 	if src == 0 {
-		songs, err = a.library.GetRandomSongs(loadSize)
+		songs, err = a.library.GetRandomSongs(fetchSize)
 	} else {
-		songs, err = a.library.GetAlbumSongs("alphabeticalByName", loadSize/a.cfg.UI.PageSize)
+		songs, err = a.library.GetAlbumSongs("alphabeticalByName")
 	}
 
 	if err != nil {
@@ -357,7 +357,9 @@ func (a *App) playSongAtIndex(index int) {
 		playingStatus := fmt.Sprintf("[#ffb300]▶ PLAYING")
 		a.updateStatus(FormatSongInfo(currentTrack, playingStatus, "◴", "[darkgray]Vol: [...", a.leftPanelTextWidth(), a.serverConnected.Load(), CreatePlayingExtras(currentTrack, a.leftPanelTextWidth())))
 
-		time.Sleep(500 * time.Millisecond)
+		a.tviewApp.QueueUpdateDraw(func() {
+			a.renderSongTable()
+		})
 	}()
 }
 

--- a/ui/formatters.go
+++ b/ui/formatters.go
@@ -35,46 +35,7 @@ func FormatDuration(seconds int) string {
 	return fmt.Sprintf("%d:%02d", minutes, secs)
 }
 
-func abs(n int) int {
-	if n < 0 {
-		return -n
-	}
-	return n
-}
-
 // ---- Geek paused extras ----
-
-var specBars = []string{" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"}
-
-func CreateFrozenSpectrum(width int) string {
-	bars := width - 4
-	if bars > 40 {
-		bars = 40
-	}
-	if bars < 10 {
-		bars = 10
-	}
-
-	var row1, row2, row3 string
-	for i := 0; i < bars; i++ {
-		phase1 := (i * 7) % 32
-		phase2 := (i*11 + 8) % 32
-		phase3 := (i*5 + 16) % 32
-
-		v1 := 8 - abs(phase1-16)/2
-		v2 := 8 - abs(phase2-16)/2
-		v3 := 8 - abs(phase3-16)/2
-		if v1 < 0 { v1 = 0 }
-		if v2 < 0 { v2 = 0 }
-		if v3 < 0 { v3 = 0 }
-
-		row1 += specBars[v1]
-		row2 += specBars[v2]
-		row3 += specBars[v3]
-	}
-
-	return fmt.Sprintf("  [#ffb300]%s\n  [#e65100]%s\n  [#5d4037]%s", row1, row2, row3)
-}
 
 func CreateOscilloscope(width int) string {
 	bars := width - 4
@@ -174,51 +135,6 @@ func CreateAudioSpecs(track domain.Song, width int) string {
 	line2 := fmt.Sprintf("%s%s%s", chStr, sizeStr, playStr)
 
 	return fmt.Sprintf("  [#ffb300]%s\n  [gray]%s", line1, line2)
-}
-
-func CreateHexDump(track domain.Song, width int) string {
-	if width < 36 {
-		return CreateGoDebug(track)
-	}
-
-	title := track.Title
-	artist := track.Artist
-	formatStr := strings.ToUpper(track.Suffix)
-
-	lines := []string{
-		hexLine(0x0000, []byte(title)),
-		hexLine(0x0010, []byte(artist)),
-	}
-
-	specData := fmt.Sprintf("%s %dHz %dkbps ch=%d", formatStr, track.SampleRate, track.BitRate, track.ChannelCount)
-	lines = append(lines, hexLine(0x0020, []byte(specData)))
-
-	var result string
-	for _, l := range lines {
-		result += "  [gray]" + l + "\n"
-	}
-	return strings.TrimRight(result, "\n")
-}
-
-func hexLine(addr int, data []byte) string {
-	hexPart := make([]byte, 0, 48)
-	for i, b := range data {
-		if i > 0 && i%8 == 0 {
-			hexPart = append(hexPart, ' ')
-		}
-		hexPart = append(hexPart, fmt.Sprintf("%02X ", b)...)
-	}
-
-	asciiPart := make([]byte, 0, 16)
-	for _, b := range data {
-		if b >= 32 && b < 127 {
-			asciiPart = append(asciiPart, b)
-		} else {
-			asciiPart = append(asciiPart, '.')
-		}
-	}
-
-	return fmt.Sprintf("%04X  %-24s %s", addr, string(hexPart), string(asciiPart))
 }
 
 func CreateGoDebug(track domain.Song) string {

--- a/ui/keybindings.go
+++ b/ui/keybindings.go
@@ -9,12 +9,6 @@ type KeyAction struct {
 	handler func()
 }
 
-type KeyBinding struct {
-	action KeyAction
-	keys   []tcell.Key // for special keys like arrows, pgdn, etc.
-	runes  []rune      // for character keys
-}
-
 type KeyBindingManager struct {
 	bindings  map[tcell.Key]KeyAction // special key -> action mapping
 	runeMap   map[rune]KeyAction      // rune -> action mapping
@@ -84,6 +78,3 @@ func (km *KeyBindingManager) HandleKey(event *tcell.EventKey) bool {
 	return false
 }
 
-func (km *KeyBindingManager) ResetPending() {
-	km.pending = ""
-}


### PR DESCRIPTION
## Summary
- Fix album song fetching: paginate through all albums via offset to get complete library (fixes missing songs for 600+ track libraries)
- Fix ▶ arrow indicator delay: refresh song table immediately after playback starts, remove unnecessary `time.Sleep(500ms)`
- Remove 183 lines of dead code (unused types, methods, constants, display functions)
- Make random songs `fetch_size` configurable via `ui.fetch_size` in config.toml (default: 500)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` 3 passed
- [ ] Manual: verify all songs appear with 600+ library
- [ ] Manual: verify ▶ arrow switches immediately on song change

🤖 Generated with [Claude Code](https://claude.com/claude-code)